### PR TITLE
Allowing the library to work with formatted errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,23 @@ This is because is defined as `type HashableMapper map[error]error`
 
 If is necessary, in the future we can have another `Mapper` implementation which supports non hashable error types.
 
+### Formatted errors
+`FormattedMapper` can be used in combination of the standard `HashableMapper` to allow to map an error format to an error.
+
+```go
+    var Errors = maperr.NewMultiErr(
+        maperr.FormattedMapper{
+            "element with %d was not found": ErrBar,
+        },
+    )
+    // NOTE: the formatted mapper only works with maperr.Errorf so won't work with fmt.Errorf
+    err = maperr.Errorf("element with %d was not found", 12345)
+    
+    if appendedErr := Errors.Mapped(err, ErrFoo); appendedErr != nil {
+        return nil, appendedErr
+    }
+```
+
 ### Example usage:
 
 Handler layer

--- a/error.go
+++ b/error.go
@@ -1,0 +1,34 @@
+package maperr
+
+import "fmt"
+
+// Errorf returns an error which persists
+func Errorf(format string, args ...interface{}) error {
+	return newFormattedError(format, args...)
+}
+
+// formattedError is a error that holds the format
+// from which the error was generated
+type formattedError struct {
+	format string
+	args   []interface{}
+	error  error
+}
+
+// newFormattedError return instance of formattedError
+func newFormattedError(format string, args ...interface{}) formattedError {
+	return formattedError{
+		format: format,
+		args:   args,
+		error:  fmt.Errorf(format, args...),
+	}
+}
+
+// Error return the actual error
+func (fe formattedError) Error() string {
+	return fe.error.Error()
+}
+
+func (fe formattedError) EqualFormat(format string) bool {
+	return fe.format == format
+}

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,13 @@
+package maperr_test
+
+import (
+	"testing"
+
+	"github.com/intelligentpos/maperr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrorf(t *testing.T) {
+	err := maperr.Errorf("some err with foo %d", 123)
+	assert.EqualError(t, err, "some err with foo 123")
+}


### PR DESCRIPTION
Introducing a new mapper `FormattedMapper` which works by comparing
only the error format string. 

This only works when the formatted error 
is created using a custom error type `maperr.Errorf("foo %d", 1)`

JIRA: IPL-499