### PR TITLE
Added maperr.Error interface used by ListMapper

### DIFF
--- a/error.go
+++ b/error.go
@@ -2,8 +2,15 @@ package maperr
 
 import "fmt"
 
+// Error which exposes a method that determines if the error
+// can be considered equal or not
+type Error interface {
+	error
+	Equal(Error) bool
+}
+
 // Errorf returns an error which persists
-func Errorf(format string, args ...interface{}) error {
+func Errorf(format string, args ...interface{}) Error {
 	return newFormattedError(format, args...)
 }
 
@@ -29,6 +36,10 @@ func (fe formattedError) Error() string {
 	return fe.error.Error()
 }
 
-func (fe formattedError) EqualFormat(format string) bool {
-	return fe.format == format
+func (fe formattedError) Equal(err Error) bool {
+	formattedErr, ok := err.(formattedError)
+	if !ok {
+		return false
+	}
+	return fe.format == formattedErr.format
 }

--- a/maperr_test.go
+++ b/maperr_test.go
@@ -100,7 +100,7 @@ func TestMap_MappedFormattedErrors(t *testing.T) {
 	errLayerTwoFailed := maperr.Errorf(errTextLayerTwoFailed, 20)
 
 	type iteration struct {
-		mapErr maperr.FormattedMapper
+		mapErr maperr.ListMapper
 		err    error
 	}
 	tests := []struct {
@@ -113,15 +113,13 @@ func TestMap_MappedFormattedErrors(t *testing.T) {
 			name: "error going through three layers",
 			iterations: []iteration{
 				{
-					mapErr: maperr.FormattedMapper{
-						errTextLayerOneFailed: errLayerTwoFailed,
-					},
+					mapErr: maperr.NewListMapper().
+						Appendf(errTextLayerOneFailed, errLayerTwoFailed),
 					err: errLayerOneFailed,
 				},
 				{
-					mapErr: maperr.FormattedMapper{
-						errTextLayerTwoFailed: maperr.Errorf("abc"),
-					},
+					mapErr: maperr.NewListMapper().
+						Append(maperr.Errorf(errTextLayerTwoFailed), maperr.Errorf("abc")),
 					err: errLayerTwoFailed,
 				},
 			},
@@ -163,7 +161,7 @@ func TestMap_LastAppended(t *testing.T) {
 			expectedPrevious: layerOneFailed,
 		},
 		{
-			name:             "several errors",
+			name:             "several errorPairs",
 			err:              multierr.Combine(layerOneFailed, layerTwoFailed, layerThreeFailed),
 			expectedPrevious: layerThreeFailed,
 		},
@@ -240,7 +238,7 @@ func TestMap_LastMappedWithStatus(t *testing.T) {
 			givenError:   errors.New("not found"),
 		},
 		{
-			name:         "mapped errors without an http status",
+			name:         "mapped errorPairs without an http status",
 			mappedErrors: mappedErrorsWithoutStatus,
 			givenError:   wrappedSecond,
 			expected: expected{


### PR DESCRIPTION
Refactoring work on the back of a comment in a previous PR https://github.com/intelligentpos/maperr/pull/4#issuecomment-414336254

The `FormatterMapper` has been renamed to `ListMapper` and refactored to work
for any error that implements the `maperr.Error` interface.

The `formattedError` type has been updated to implement the `maperr.Error`

Closes #5