### PR TITLE
Allow IgnoreListMapper to work with std library errors

### DIFF
--- a/ignore_list.go
+++ b/ignore_list.go
@@ -32,8 +32,9 @@ func (lm IgnoreListMapper) Map(err error) MapResult {
 
 	comparableErr, ok := toMap.(Error)
 	if !ok {
-		return nil
+		comparableErr = NewError(toMap.Error())
 	}
+
 	for k := range lm.list {
 		if !comparableErr.Equal(lm.list[k]) {
 			continue

--- a/ignore_list_test.go
+++ b/ignore_list_test.go
@@ -8,7 +8,8 @@ import (
 )
 
 func Test_IgnoreListMapper_Map_IgnoreErrorFound(t *testing.T) {
-	errLayerOneFailed := maperr.NewError("layer 1 failed")
+	errLayerOneFailed := maperr.NewError("maperr error")
+	stdLibraryError := errors.New("maperr error")
 	errTextLayerTwoFailed := "bar %d"
 
 	tests := []struct {
@@ -18,6 +19,10 @@ func Test_IgnoreListMapper_Map_IgnoreErrorFound(t *testing.T) {
 		{
 			name:  "error ignored",
 			given: errLayerOneFailed,
+		},
+		{
+			name:  "std library error ignored",
+			given: stdLibraryError,
 		},
 		{
 			name:  "formatted error ignored",


### PR DESCRIPTION
Small change that allows IgnoreListMapper to work with stdlibrary
errors as well as maperr.Error interface

Satisfies JIRA Ticket: https://izettle.atlassian.net/browse/MSEU-497