### PR TITLE
Mapped should return nil immediately when error is nil

### DIFF
--- a/maperr.go
+++ b/maperr.go
@@ -43,10 +43,13 @@ func NewMultiErr(mapper ...Mapper) MultiErr {
 
 // Mapped appends the mapped error or a default one when is not found
 func (m MultiErr) Mapped(err, defaultErr error) error {
+	if err == nil {
+		return nil
+	}
 	if res := m.mappers.Map(err); res != nil {
 		return res.Apply()
 	}
-	if err != nil && defaultErr != nil {
+	if defaultErr != nil {
 		return Append(err, defaultErr)
 	}
 	return err

--- a/maperr_test.go
+++ b/maperr_test.go
@@ -36,6 +36,12 @@ func TestMultiErr_Mapped(t *testing.T) {
 		expectedErr  string
 	}{
 		{
+			name:         "error is nil",
+			mappedErrors: multipleMappers,
+			givenError:   nil,
+			expectedErr:  "",
+		},
+		{
 			name:         "second is ignored",
 			mappedErrors: multipleMappers,
 			givenError:   maperr.Append(first, second),


### PR DESCRIPTION
Avoid unnecessary loops when the error is nil and nothing
needs to be mapped to nil.

Satisfies JIRA Ticket: https://izettle.atlassian.net/browse/MSEU-497