### PR TITLE
Allow to retrieve a maperr.Error from a chain

### DIFF
--- a/error.go
+++ b/error.go
@@ -15,6 +15,18 @@ func Errorf(format string, args ...interface{}) Error {
 	return newFormattedError(format, args...)
 }
 
+// CastError cast an error to maperr.Error when possible
+// otherwise creates a new maperr.Error
+func CastError(err error) Error {
+	if err == nil {
+		return nil
+	}
+	if mapError, ok := err.(Error); ok {
+		return mapError
+	}
+	return NewError(err.Error())
+}
+
 // NewError instantiates an Error with no formatting
 func NewError(errText string) Error {
 	return Errorf(errText)

--- a/maperr.go
+++ b/maperr.go
@@ -112,6 +112,25 @@ func LastAppended(err error) error {
 	return nil
 }
 
+// HasEqual find the first equal error on a chain of errors
+// and returns it
+func HasEqual(chain, err error) Error {
+	mapError := CastError(err)
+
+	multiErrList := multierr.Errors(chain)
+	if len(multiErrList) == 0 {
+		return nil
+	}
+
+	for _, wrapped := range multiErrList {
+		wrappedMapError := CastError(wrapped)
+		if wrappedMapError.Equal(mapError) {
+			return wrappedMapError
+		}
+	}
+	return nil
+}
+
 // HasError checks if an error has been wrapped
 func HasError(err error, errText string) bool {
 	multiErrList := multierr.Errors(err)


### PR DESCRIPTION
Adds a maperr.Error which loops trough all errors that
were appended to it and returns the first that is Equal.

It also adds a CastError to convert stdlibrary error to
maperr.Error