### PR TITLE
Allow Map on list mapper to accept std library errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,6 @@ module github.com/iZettle/maperr
 go 1.12
 
 require (
-	github.com/davecgh/go-spew v1.1.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.3.0
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0

--- a/list.go
+++ b/list.go
@@ -39,10 +39,7 @@ func (lm ListMapper) Map(err error) MapResult {
 		toMap = previous
 	}
 
-	comparableErr, ok := toMap.(Error)
-	if !ok {
-		return nil
-	}
+	comparableErr := CastError(toMap)
 	for k := range lm.errorPairs {
 		if !comparableErr.Equal(lm.errorPairs[k].err) {
 			continue

--- a/list_test.go
+++ b/list_test.go
@@ -1,6 +1,7 @@
 package maperr_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/iZettle/maperr"
@@ -30,6 +31,11 @@ func TestMap_MappedFormattedErrors(t *testing.T) {
 			iterations: []iteration{
 				{
 					mapErr: maperr.NewListMapper().
+						Append(maperr.NewError("normal error"), errLayerOneFailed),
+					err: errors.New("normal error"),
+				},
+				{
+					mapErr: maperr.NewListMapper().
 						Appendf(errTextLayerOneFailed, errLayerTwoFailed),
 					err: errLayerOneFailed,
 				},
@@ -39,7 +45,7 @@ func TestMap_MappedFormattedErrors(t *testing.T) {
 					err: errLayerTwoFailed,
 				},
 			},
-			expectedErr: "foo 10; bar 20; abc",
+			expectedErr: "normal error; foo 10; bar 20; abc",
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
Currently if Map is called on a ListMapper, and is not a maperr.Error
it will not map.

With this change it will cast the error to a maperr.Error and
map it using the maperr.Error.Equal() which will default to an
exact text value comparison for std errors.