### PR TITLE
Current version of maperr is incompatible with Go 1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/iZettle/maperr
+module github.com/iZettle/maperr/v4
 
 go 1.12
 


### PR DESCRIPTION
This adds the v4 path so as that Go can pull this in 1.13