### PR TITLE
Uses the new errors.As from 1.13

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,6 +1,9 @@
 package maperr
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // Error which exposes a method that determines if the error
 // can be considered equal or not
@@ -21,9 +24,12 @@ func CastError(err error) Error {
 	if err == nil {
 		return nil
 	}
-	if mapError, ok := err.(Error); ok {
+
+	var mapError Error
+	if errors.As(err, &mapError) {
 		return mapError
 	}
+
 	return NewError(err.Error())
 }
 
@@ -60,9 +66,9 @@ func (fe formattedError) Hashable() error {
 }
 
 func (fe formattedError) Equal(err Error) bool {
-	formattedErr, ok := err.(formattedError)
-	if !ok {
-		return false
+	var ferr formattedError
+	if errors.As(err, &ferr) {
+		return fe.format == ferr.format
 	}
-	return fe.format == formattedErr.format
+	return false
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,5 @@ go 1.13
 
 require (
 	github.com/stretchr/testify v1.4.0
-	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/hashable.go
+++ b/hashable.go
@@ -1,5 +1,9 @@
 package maperr
 
+import (
+	"errors"
+)
+
 // HashableMapper simple implementation of Mapper which only works
 // on hashable error keys
 type HashableMapper map[error]error
@@ -34,8 +38,11 @@ func (hm HashableMapper) Map(err error) MapResult {
 
 func (hm HashableMapper) tryMakeHashable(err error) error {
 	key := err
-	if casted, ok := err.(formattedError); ok {
-		key = casted.Hashable()
+
+	var ferr formattedError
+	if errors.As(err, &ferr) {
+		key = ferr.Hashable()
 	}
+
 	return key
 }

--- a/maperr.go
+++ b/maperr.go
@@ -76,11 +76,13 @@ func (m MultiErr) LastMappedWithStatus(err error) ErrorWithStatusProvider {
 	if lastMapped == nil {
 		return nil
 	}
-	statusErr, ok := lastMapped.(ErrorWithStatusProvider)
-	if !ok {
-		return nil
+
+	var statusErr ErrorWithStatusProvider
+	if errors.As(lastMapped, &statusErr) {
+		return statusErr
 	}
-	return statusErr
+
+	return nil
 }
 
 type errorWithStatus struct {

--- a/maperr_test.go
+++ b/maperr_test.go
@@ -112,12 +112,18 @@ func TestMultiErr_LastMapped(t *testing.T) {
 func TestMultiErr_LastMappedWithStatus(t *testing.T) {
 	first := errors.New("first")
 	second := errors.New("second")
+
 	wrappedSecond := maperr.
 		Append(first, second)
-	mappedErrorsWithStatus := maperr.NewHashableMapper().
+
+	mappedErrorsWithStatus := maperr.
+		NewHashableMapper().
 		Append(second, maperr.WithStatus("third", http.StatusInternalServerError))
-	mappedErrorsWithoutStatus := maperr.NewHashableMapper().
+
+	mappedErrorsWithoutStatus := maperr.
+		NewHashableMapper().
 		Append(second, errors.New("third"))
+
 	type expected struct {
 		status int
 		err    string
@@ -271,8 +277,8 @@ func Test_HasEqual(t *testing.T) {
 			expected: maperr.NewError("three"),
 		},
 		{
-			name:     "formatted error to be found is in the list with a different id",
-			errList:  multierr.Combine(
+			name: "formatted error to be found is in the list with a different id",
+			errList: multierr.Combine(
 				errors.New("one"),
 				maperr.Errorf("this is a formatted error %d", 12345),
 				errors.New("two"),


### PR DESCRIPTION
Go 1.13 shipped a new `errors.As` which allows to find
an error of a specific type without having to do manual type assertion.

I've replaced it where it was relevant which tidy up some code.

Resolves #27