### PR TITLE
Swaps the use of map.Error with std library errors

### DIFF
--- a/error.go
+++ b/error.go
@@ -9,7 +9,7 @@ import (
 // can be considered equal or not
 type Error interface {
 	error
-	Equal(Error) bool
+	Equal(error) bool
 	Hashable() error
 }
 
@@ -18,9 +18,9 @@ func Errorf(format string, args ...interface{}) Error {
 	return newFormattedError(format, args...)
 }
 
-// CastError cast an error to maperr.Error when possible
+// castError cast an error to maperr.Error when possible
 // otherwise creates a new maperr.Error
-func CastError(err error) Error {
+func castError(err error) Error {
 	if err == nil {
 		return nil
 	}
@@ -60,15 +60,23 @@ func (fe formattedError) Error() string {
 	return fe.err.Error()
 }
 
+// Unwrap return the actual error
+func (fe formattedError) Unwrap() error {
+	return fe.err
+}
+
 // Error return the hashable error
 func (fe formattedError) Hashable() error {
 	return fe.err
 }
 
-func (fe formattedError) Equal(err Error) bool {
+func (fe formattedError) Equal(err error) bool {
+	if err == nil {
+		return false
+	}
 	var ferr formattedError
 	if errors.As(err, &ferr) {
 		return fe.format == ferr.format
 	}
-	return false
+	return fe.Error() == err.Error()
 }

--- a/error_test.go
+++ b/error_test.go
@@ -1,13 +1,22 @@
 package maperr_test
 
 import (
+	"errors"
 	"testing"
 
-	"github.com/iZettle/maperr/v4"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/iZettle/maperr/v4"
 )
 
 func TestErrorf(t *testing.T) {
 	err := maperr.Errorf("some err with foo %d", 123)
 	assert.EqualError(t, err, "some err with foo 123")
+}
+
+func TestNewError(t *testing.T) {
+	err := maperr.NewError("some error")
+	if !err.Equal(errors.New("some error")) {
+		t.Fatal("expected errors to be equal")
+	}
 }

--- a/hashable.go
+++ b/hashable.go
@@ -33,7 +33,7 @@ func (hm HashableMapper) Map(err error) MapResult {
 	if !ok {
 		return nil
 	}
-	return NewAppendStrategy(err, mapped)
+	return newAppendStrategy(err, mapped)
 }
 
 func (hm HashableMapper) tryMakeHashable(err error) error {

--- a/ignore_list.go
+++ b/ignore_list.go
@@ -1,6 +1,6 @@
 package maperr
 
-// IgnoreListMapper is a mapper that allow to specify a list of error that we
+// IgnoreListMapper is a Mapper that allow to specify a list of error that we
 // want to ignore
 type IgnoreListMapper struct {
 	list []Error
@@ -17,8 +17,8 @@ func (lm IgnoreListMapper) Appendf(format string) IgnoreListMapper {
 }
 
 // Append appends an error that we want to ignore
-func (lm IgnoreListMapper) Append(err Error) IgnoreListMapper {
-	lm.list = append(lm.list, err)
+func (lm IgnoreListMapper) Append(err error) IgnoreListMapper {
+	lm.list = append(lm.list, castError(err))
 	return lm
 }
 
@@ -30,45 +30,42 @@ func (lm IgnoreListMapper) Map(err error) MapResult {
 		toMap = previous
 	}
 
-	comparableErr, ok := toMap.(Error)
-	if !ok {
-		comparableErr = NewError(toMap.Error())
-	}
+	comparableErr := castError(toMap)
 
 	for k := range lm.list {
 		if !comparableErr.Equal(lm.list[k]) {
 			continue
 		}
-		return NewIgnoreStrategy(err)
+		return newIgnoreStrategy(err)
 	}
 	return nil
 }
 
-// IgnoreStrategy holds data for an ignore strategy
-type IgnoreStrategy struct {
+// ignoreStrategy holds data for an ignore strategy
+type ignoreStrategy struct {
 	previous error
 }
 
-// NewIgnoreStrategy instantiates a new IgnoreStrategy
-func NewIgnoreStrategy(previous error) IgnoreStrategy {
-	return IgnoreStrategy{
+// newIgnoreStrategy instantiates a new ignoreStrategy
+func newIgnoreStrategy(previous error) ignoreStrategy {
+	return ignoreStrategy{
 		previous: previous,
 	}
 }
 
 // Previous holds the error that we wanted to ignore
-func (as IgnoreStrategy) Previous() error {
+func (as ignoreStrategy) Previous() error {
 	return as.previous
 }
 
 // Last is defined to implement the interface
 // returns nil since we are always mapping to nil for this strategy
-func (as IgnoreStrategy) Last() error {
+func (as ignoreStrategy) Last() error {
 	return nil
 }
 
 // Apply is defined to implement the interface
 // returns nil since we are always mapping to nil for this strategy
-func (as IgnoreStrategy) Apply() error {
+func (as ignoreStrategy) Apply() error {
 	return nil
 }

--- a/ignore_list_test.go
+++ b/ignore_list_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test_IgnoreListMapper_Map_IgnoreErrorFound(t *testing.T) {
-	errLayerOneFailed := maperr.NewError("maperr error")
+	errLayerOneFailed := errors.New("maperr error")
 	stdLibraryError := errors.New("maperr error")
 	errTextLayerTwoFailed := "bar %d"
 
@@ -62,7 +62,7 @@ func Test_IgnoreListMapper_Map_IgnoreErrorFound(t *testing.T) {
 }
 
 func Test_IgnoreListMapper_Map_IgnoreErrorNotFound(t *testing.T) {
-	errLayerOneFailed := maperr.NewError("layer 1 failed")
+	errLayerOneFailed := errors.New("layer 1 failed")
 	errTextLayerTwoFailed := "bar %d"
 
 	tests := []struct {
@@ -98,7 +98,7 @@ func Test_IgnoreListMapper_Map_IgnoreErrorNotFound(t *testing.T) {
 }
 
 func Test_IgnoreListMapper_Map_WithMultiErr(t *testing.T) {
-	errLayerOneFailed := maperr.NewError("layer 1 failed")
+	errLayerOneFailed := errors.New("layer 1 failed")
 	errTextLayerTwoFailed := "bar %d"
 
 	tests := []struct {

--- a/list.go
+++ b/list.go
@@ -17,16 +17,16 @@ func NewListMapper() ListMapper {
 }
 
 // Appendf append a format to error association
-func (lm ListMapper) Appendf(format string, match Error) ListMapper {
-	return lm.Append(Errorf(format), match)
+func (lm ListMapper) Appendf(format string, match error) ListMapper {
+	return lm.Append(Errorf(format), castError(match))
 }
 
 // Append append an error to error association
-func (lm ListMapper) Append(err, match Error) ListMapper {
+func (lm ListMapper) Append(err, match error) ListMapper {
 	lm.errorPairs = append(lm.errorPairs,
 		PairErrors{
-			err:   err,
-			match: match,
+			err:   castError(err),
+			match: castError(match),
 		})
 	return lm
 }
@@ -39,39 +39,39 @@ func (lm ListMapper) Map(err error) MapResult {
 		toMap = previous
 	}
 
-	comparableErr := CastError(toMap)
+	comparableErr := castError(toMap)
 	for k := range lm.errorPairs {
 		if !comparableErr.Equal(lm.errorPairs[k].err) {
 			continue
 		}
-		return NewAppendStrategy(err, lm.errorPairs[k].match)
+		return newAppendStrategy(err, lm.errorPairs[k].match)
 	}
 	return nil
 }
 
-// AppendStrategy holds data for an ignore strategy
-type AppendStrategy struct {
+// appendStrategy holds data for an ignore strategy
+type appendStrategy struct {
 	previous error
 	last     error
 }
 
-// NewAppendStrategy instantiates a new AppendStrategy
-func NewAppendStrategy(previous, last error) AppendStrategy {
-	return AppendStrategy{previous: previous, last: last}
+// newAppendStrategy instantiates a new appendStrategy
+func newAppendStrategy(previous, last error) appendStrategy {
+	return appendStrategy{previous: previous, last: last}
 }
 
 // Previous returns the error that we want to append to
-func (as AppendStrategy) Previous() error {
+func (as appendStrategy) Previous() error {
 	return as.previous
 }
 
 // Last returns the error that we are appending
-func (as AppendStrategy) Last() error {
+func (as appendStrategy) Last() error {
 	return as.last
 }
 
 // Apply the append strategy by appending previous to last
-func (as AppendStrategy) Apply() error {
+func (as appendStrategy) Apply() error {
 	if as.last == nil {
 		return nil
 	}

--- a/maperr_test.go
+++ b/maperr_test.go
@@ -11,11 +11,11 @@ import (
 )
 
 func TestMultiErr_Mapped(t *testing.T) {
-	first := maperr.NewError("first")
-	second := maperr.NewError("second")
-	third := maperr.NewError("third")
-	forth := maperr.NewError("forth")
-	fifth := maperr.NewError("fifth")
+	first := errors.New("first")
+	second := errors.New("second")
+	third := errors.New("third")
+	forth := errors.New("forth")
+	fifth := errors.New("fifth")
 
 	multipleMappers := maperr.NewMultiErr(
 		maperr.NewIgnoreListMapper().
@@ -63,43 +63,6 @@ func TestMultiErr_Mapped(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actualErr := test.mappedErrors.Mapped(test.givenError, errors.New("default"))
-			if test.expectedErr != "" {
-				assert.EqualError(t, actualErr, test.expectedErr)
-			} else {
-				assert.NoError(t, actualErr)
-			}
-		})
-	}
-}
-
-func TestMultiErr_LastMapped(t *testing.T) {
-	first := errors.New("first")
-	second := errors.New("second")
-	third := errors.New("third")
-	wrappedSecond := maperr.Append(first, second)
-	mappedErrors := maperr.NewHashableMapper().
-		Append(second, third)
-	tests := []struct {
-		name         string
-		mappedErrors maperr.HashableMapper
-		givenError   error
-		expectedErr  string
-	}{
-		{
-			name:         "last error was not found",
-			mappedErrors: mappedErrors,
-			givenError:   errors.New("not found"),
-		},
-		{
-			name:         "last error was mapped and wrapped",
-			mappedErrors: mappedErrors,
-			givenError:   wrappedSecond,
-			expectedErr:  "third",
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			actualErr := maperr.NewMultiErr(test.mappedErrors).LastMapped(test.givenError)
 			if test.expectedErr != "" {
 				assert.EqualError(t, actualErr, test.expectedErr)
 			} else {
@@ -160,7 +123,7 @@ func TestMultiErr_LastMappedWithStatus(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actualErr := maperr.NewMultiErr(test.mappedErrors).LastMappedWithStatus(test.givenError)
+			actualErr := maperr.NewMultiErr(test.mappedErrors).MappedWithStatus(test.givenError)
 			if test.expected.err != "" {
 				assert.EqualError(t, actualErr, test.expected.err)
 			} else {
@@ -244,7 +207,7 @@ func Test_HasEqual(t *testing.T) {
 		name     string
 		errList  error
 		toFind   error
-		expected maperr.Error
+		expected error
 	}{
 		{
 			name:     "error to be found is nil",
@@ -268,13 +231,13 @@ func Test_HasEqual(t *testing.T) {
 			name:     "error to be found is in the list",
 			errList:  multierr.Combine(errors.New("one"), errors.New("two"), errors.New("three")),
 			toFind:   errors.New("three"),
-			expected: maperr.NewError("three"),
+			expected: errors.New("three"),
 		},
 		{
 			name:     "maperr.Error to be found is in the list",
 			errList:  multierr.Combine(errors.New("one"), errors.New("two"), errors.New("three")),
-			toFind:   maperr.NewError("three"),
-			expected: maperr.NewError("three"),
+			toFind:   errors.New("three"),
+			expected: errors.New("three"),
 		},
 		{
 			name: "formatted error to be found is in the list with a different id",


### PR DESCRIPTION
Since `maperr.Error` decorates `errors` is not a breaking change to
just use `errors`.

This change does that, and then does some casting within each function
that was expecting an `map.Error`.

This will simplify the use of the library and allow any mapper to work
with the `maperr.WithStatus` func

Other changes:
 - `errorWithStatus` and `formattedError` implement the `Unwrapper` interface
 - several types that had not been use anywhere except this library have
been unexported: `castError`, `newAppendStrategy`, `ignoreStrategy`,
`lastMapped`,
 - Added alias `LastMappedWithStatus` of `MappedWithStatus`