### PR TITLE
When mapping look for any error that match the first in the entire chain

### DIFF
--- a/ignore_list_test.go
+++ b/ignore_list_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"testing"
 
+	"go.uber.org/multierr"
+
 	"github.com/iZettle/maperr/v4"
 )
 
@@ -135,5 +137,27 @@ func Test_IgnoreListMapper_Map_WithMultiErr(t *testing.T) {
 				t.Fatalf("expected nil got err %s", mappedErr.Error())
 			}
 		})
+	}
+}
+
+func TestMap_IgnoreListMapper_FindAnyErrorInChain(t *testing.T) {
+	errSecond := errors.New("second error")
+
+	errChain := multierr.Combine(
+		errors.New("first error"),
+		errSecond,
+		errors.New("third error"),
+		errors.New("forth error"),
+		errors.New("fifth error"),
+	)
+
+	mappedErr := maperr.NewMultiErr(
+		maperr.
+			NewIgnoreListMapper().
+			Append(errSecond),
+	).Mapped(errChain, nil)
+
+	if mappedErr != nil {
+		t.Fatal("expected nil got err")
 	}
 }

--- a/maperr.go
+++ b/maperr.go
@@ -109,7 +109,7 @@ func (ews errorWithStatus) Error() string {
 
 // WithStatus return an error with an associated status
 func WithStatus(err string, status int) error {
-	return &errorWithStatus{
+	return errorWithStatus{
 		err:    errors.New(err),
 		status: status,
 	}


### PR DESCRIPTION
The mappers are currenlty strict in the way they search for a mapped
error. They only look for the last one that was appended to the chain.

This can cause issues if within the same layer new errors are appended 
at the end - this could break the mapping on the layer above if is not updated.

This change ensures that when an error is mapped, the `Map()` func
sequentially looks for any error that match in the entire chain.

This is similar a similar behaviour as the stdlib `errors.As` and `errors.Is` do
as they unwrap errors until a match is found.

Other changes:
 - Improved readme documenting the `map.WithStatus` usage