### PR TITLE
When an error is not found in the mappings default to server error

### DIFF
--- a/maperr.go
+++ b/maperr.go
@@ -2,6 +2,7 @@ package maperr
 
 import (
 	"errors"
+	"net/http"
 
 	"go.uber.org/multierr"
 )
@@ -74,6 +75,9 @@ type ErrorWithStatusProvider interface {
 // MappedWithStatus return the last mapped error with the associated http status
 func (m MultiErr) MappedWithStatus(err error) ErrorWithStatusProvider {
 	lastMapped := m.lastMapped(err)
+	if lastMapped == nil && err != nil {
+		return newErrorWithStatus(err, http.StatusInternalServerError)
+	}
 	if lastMapped == nil {
 		return nil
 	}
@@ -94,6 +98,10 @@ func (m MultiErr) LastMappedWithStatus(err error) ErrorWithStatusProvider {
 type errorWithStatus struct {
 	err    error
 	status int
+}
+
+func newErrorWithStatus(err error, status int) errorWithStatus {
+	return errorWithStatus{err: err, status: status}
 }
 
 func (ews errorWithStatus) Status() int {

--- a/maperr_test.go
+++ b/maperr_test.go
@@ -106,6 +106,10 @@ func TestMultiErr_LastMappedWithStatus(t *testing.T) {
 			name:         "last error was not found",
 			mappedErrors: mappedErrorsWithStatus,
 			givenError:   errors.New("not found"),
+			expected: expected{
+				status: http.StatusInternalServerError,
+				err:    "not found",
+			},
 		},
 		{
 			name:         "mapped errorPairs without an http status",


### PR DESCRIPTION
Currenlty when an error is not found in a mapping, it returns `nil`.
This means that the caller then is required to make an extra check
for `if err != nil` so can return a server error.

With this change, that extra check won't be required as if we have an
error that isn't mapped, is usually flagged a server error.

Satisfies JIRA Ticket: https://izettle.atlassian.net/browse/MSEU-1561