### PR TITLE
Allow to provide default error using MappedWithStatus

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ func (h Handler) GetByTerminal(rw http.ResponseWriter, r *http.Request) jsonhand
     layoutSet, err := h.Controller.GetListByTerminal(r.Context(), siteID, terminalID)
     
     // user errors
-    if errWithStatus := handlerErrors.LastMappedWithStatus(err); errWithStatus != nil {
+    if errWithStatus := handlerErrors.MappedWithStatus(err, maperr.WithStatusInternalServerError); errWithStatus != nil {
             return jsonhandler.NewLoggableResponseWithError(
                 errWithStatus.Status(),
                 errWithStatus.Error(),


### PR DESCRIPTION
`MappedWithStatus` has been changed to allow the caller to specify
the default error that have to be used when the error is not mapped.

This allows to take advantage of the new
`jsonhandler.NewLoggableResponseFromErrorWithStatus` in the following
way.

```go
if mappedErr := errMapper.MappedWithStatus(err, maperr.WithStatusInternalServerError); mappedErr != nil {
	return jsonhandler.NewLoggableResponseFromErrorWithStatus(mappedErr)
}
```

Services tent to use `maperr.LastMappedWithStatus` which will keep
behaving as it currently does so preserve backwards compatibility.

Satisfies JIRA Ticket: https://izettle.atlassian.net/browse/MSEU-1571