### PR TITLE
Deprecate LastMappedWithStatus

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,16 +77,8 @@ func (h Handler) GetByTerminal(rw http.ResponseWriter, r *http.Request) jsonhand
     ...
     layoutSet, err := h.Controller.GetListByTerminal(r.Context(), siteID, terminalID)
     
-    // user errors
-    if errWithStatus := handlerErrors.MappedWithStatus(err, maperr.WithStatusInternalServerError); errWithStatus != nil {
-            return jsonhandler.NewLoggableResponseWithError(
-                errWithStatus.Status(),
-                errWithStatus.Error(),
-                err)
-        }
-    // server errors
-    if err != nil {
-        return jsonhandler.ServerError(err)
+    if mappedErr := errMapper.MappedWithStatus(err, maperr.WithStatusInternalServerError); mappedErr != nil {
+         return jsonhandler.NewLoggableResponseFromErrorWithStatus(mappedErr)
     }
 ```
 

--- a/maperr.go
+++ b/maperr.go
@@ -112,6 +112,7 @@ func (m MultiErr) MappedWithStatus(err, defaultErr error) ErrorWithStatusProvide
 }
 
 // LastMappedWithStatus return the last mapped error with the associated http status
+// Deprecated: consider using MappedWithStatus() instead, as encourages to specify a default error
 func (m MultiErr) LastMappedWithStatus(err error) ErrorWithStatusProvider {
 	return m.MappedWithStatus(err, nil)
 }


### PR DESCRIPTION
Deprecates LastMappedWithStatus in favour of MappedWithStatus
which is more explicit about what error is returned as default
when the error is not found in the map.