### PR TITLE
Unexport func with are not actively used

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*   @iZettle/mse-understand

--- a/hashable.go
+++ b/hashable.go
@@ -23,8 +23,8 @@ func (hm HashableMapper) Append(err, match error) HashableMapper {
 	return hm
 }
 
-// Map an error to another error
-func (hm HashableMapper) Map(err error) MapResult {
+// mapErr an error to another error
+func (hm HashableMapper) mapErr(err error) mapResult {
 	errorsToMap := []error{
 		err,
 	}

--- a/hashable_test.go
+++ b/hashable_test.go
@@ -102,14 +102,14 @@ func TestMap_Mapped_FindAnyErrorInChain(t *testing.T) {
 	mappedErr := maperr.NewMultiErr(
 		maperr.
 			NewHashableMapper().
-			Append(errSecond, errors.New("this should be appended on Map()")),
+			Append(errSecond, errors.New("this should be appended on mapErr()")),
 	).Mapped(errChain, nil)
 
 	if mappedErr == nil {
 		t.Fatal("expected err got nil")
 	}
 
-	expected := "first error; second error; third error; forth error; fifth error; this should be appended on Map()"
+	expected := "first error; second error; third error; forth error; fifth error; this should be appended on mapErr()"
 	got := mappedErr.Error()
 	if got != expected {
 		t.Fatalf("expected %s got %s", expected, got)

--- a/ignore_list.go
+++ b/ignore_list.go
@@ -26,8 +26,8 @@ func (lm IgnoreListMapper) Append(err error) IgnoreListMapper {
 	return lm
 }
 
-// Map an error to an ignore strategy
-func (lm IgnoreListMapper) Map(err error) MapResult {
+// mapErr an error to an ignore strategy
+func (lm IgnoreListMapper) mapErr(err error) mapResult {
 	errorsToMap := []error{
 		err,
 	}
@@ -49,29 +49,29 @@ func (lm IgnoreListMapper) Map(err error) MapResult {
 
 // ignoreStrategy holds data for an ignore strategy
 type ignoreStrategy struct {
-	previous error
+	previousErr error
 }
 
 // newIgnoreStrategy instantiates a new ignoreStrategy
 func newIgnoreStrategy(previous error) ignoreStrategy {
 	return ignoreStrategy{
-		previous: previous,
+		previousErr: previous,
 	}
 }
 
-// Previous holds the error that we wanted to ignore
-func (as ignoreStrategy) Previous() error {
-	return as.previous
+// previous holds the error that we wanted to ignore
+func (as ignoreStrategy) previous() error {
+	return as.previousErr
 }
 
-// Last is defined to implement the interface
+// last is defined to implement the interface
 // returns nil since we are always mapping to nil for this strategy
-func (as ignoreStrategy) Last() error {
+func (as ignoreStrategy) last() error {
 	return nil
 }
 
-// Apply is defined to implement the interface
+// apply is defined to implement the interface
 // returns nil since we are always mapping to nil for this strategy
-func (as ignoreStrategy) Apply() error {
+func (as ignoreStrategy) apply() error {
 	return nil
 }

--- a/ignore_list_test.go
+++ b/ignore_list_test.go
@@ -9,96 +9,6 @@ import (
 	"github.com/iZettle/maperr/v4"
 )
 
-func Test_IgnoreListMapper_Map_IgnoreErrorFound(t *testing.T) {
-	errLayerOneFailed := errors.New("maperr error")
-	stdLibraryError := errors.New("maperr error")
-	errTextLayerTwoFailed := "bar %d"
-
-	tests := []struct {
-		name  string
-		given error
-	}{
-		{
-			name:  "error ignored",
-			given: errLayerOneFailed,
-		},
-		{
-			name:  "std library error ignored",
-			given: stdLibraryError,
-		},
-		{
-			name:  "formatted error ignored",
-			given: maperr.Errorf(errTextLayerTwoFailed, "foo"),
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			// append the error at the end of a series of errors to ensure
-			// that we are comparing against the last error
-			chainOfErrors := maperr.Combine(
-				errors.New("first"),
-				errors.New("second"),
-				errors.New("third"),
-				test.given,
-			)
-
-			ignoreMapper := maperr.NewIgnoreListMapper().
-				Append(errLayerOneFailed).
-				Appendf(errTextLayerTwoFailed)
-
-			res := ignoreMapper.Map(chainOfErrors)
-			if res == nil {
-				t.Fatal("expected a map result object")
-			}
-			if res.Previous().Error() != chainOfErrors.Error() {
-				t.Fatalf("expected %s got %s", chainOfErrors.Error(), res.Previous().Error())
-			}
-			if res.Last() != nil {
-				t.Fatalf("expected nil got %s", res.Last().Error())
-			}
-			if res.Apply() != nil {
-				t.Fatalf("expected nil got %s", res.Apply().Error())
-			}
-		})
-	}
-}
-
-func Test_IgnoreListMapper_Map_IgnoreErrorNotFound(t *testing.T) {
-	errLayerOneFailed := errors.New("layer 1 failed")
-	errTextLayerTwoFailed := "bar %d"
-
-	tests := []struct {
-		name  string
-		given error
-	}{
-		{
-			name:  "not found",
-			given: errors.New("not found"),
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			// append the error at the end of a series of errors to ensure
-			// that we are comparing against the last error
-			chainOfErrors := maperr.Combine(
-				errors.New("first"),
-				errors.New("second"),
-				errors.New("third"),
-				test.given,
-			)
-
-			ignoreMapper := maperr.NewIgnoreListMapper().
-				Append(errLayerOneFailed).
-				Appendf(errTextLayerTwoFailed)
-
-			res := ignoreMapper.Map(chainOfErrors)
-			if res != nil {
-				t.Fatal("expected nil got a map result object")
-			}
-		})
-	}
-}
-
 func Test_IgnoreListMapper_Map_WithMultiErr(t *testing.T) {
 	errLayerOneFailed := errors.New("layer 1 failed")
 	errTextLayerTwoFailed := "bar %d"
@@ -119,7 +29,7 @@ func Test_IgnoreListMapper_Map_WithMultiErr(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// append the error at the end of a series of errors to ensure
-			// that we are comparing against the last error
+			// that we are comparing against the lastErr error
 			chainOfErrors := maperr.Combine(
 				errors.New("first"),
 				errors.New("second"),

--- a/list.go
+++ b/list.go
@@ -35,8 +35,8 @@ func (lm ListMapper) Append(err, match error) ListMapper {
 	return lm
 }
 
-// Map a formatted error to an error
-func (lm ListMapper) Map(err error) MapResult {
+// mapErr a formatted error to an error
+func (lm ListMapper) mapErr(err error) mapResult {
 	errorsToMap := []error{
 		err,
 	}
@@ -58,29 +58,29 @@ func (lm ListMapper) Map(err error) MapResult {
 
 // appendStrategy holds data for an ignore strategy
 type appendStrategy struct {
-	previous error
-	last     error
+	previousErr error
+	lastErr     error
 }
 
 // newAppendStrategy instantiates a new appendStrategy
 func newAppendStrategy(previous, last error) appendStrategy {
-	return appendStrategy{previous: previous, last: last}
+	return appendStrategy{previousErr: previous, lastErr: last}
 }
 
-// Previous returns the error that we want to append to
-func (as appendStrategy) Previous() error {
-	return as.previous
+// previous returns the error that we want to append to
+func (as appendStrategy) previous() error {
+	return as.previousErr
 }
 
-// Last returns the error that we are appending
-func (as appendStrategy) Last() error {
-	return as.last
+// last returns the error that we are appending
+func (as appendStrategy) last() error {
+	return as.lastErr
 }
 
-// Apply the append strategy by appending previous to last
-func (as appendStrategy) Apply() error {
-	if as.last == nil {
+// apply the append strategy by appending previousErr to lastErr
+func (as appendStrategy) apply() error {
+	if as.lastErr == nil {
 		return nil
 	}
-	return Append(as.previous, as.last)
+	return Append(as.previousErr, as.lastErr)
 }

--- a/list_test.go
+++ b/list_test.go
@@ -78,14 +78,14 @@ func TestMap_ListMapper_FindAnyErrorInChain(t *testing.T) {
 	mappedErr := maperr.NewMultiErr(
 		maperr.
 			NewListMapper().
-			Append(errSecond, errors.New("this should be appended on Map()")),
+			Append(errSecond, errors.New("this should be appended on mapErr()")),
 	).Mapped(errChain, nil)
 
 	if mappedErr == nil {
 		t.Fatal("expected err got nil")
 	}
 
-	expected := "first error; second error; third error; forth error; fifth error; this should be appended on Map()"
+	expected := "first error; second error; third error; forth error; fifth error; this should be appended on mapErr()"
 	got := mappedErr.Error()
 	if got != expected {
 		t.Fatalf("expected %s got %s", expected, got)

--- a/maperr_test.go
+++ b/maperr_test.go
@@ -48,13 +48,13 @@ func TestMultiErr_Mapped(t *testing.T) {
 			expectedErr:  "",
 		},
 		{
-			name:         "when errListErrorTwo is last error, errListErrorThree is mapped and appended",
+			name:         "when errListErrorTwo is lastErr error, errListErrorThree is mapped and appended",
 			mappedErrors: multipleMappers,
 			givenError:   maperr.Combine(first, errListErrorOne, errListErrorTwo),
 			expectedErr:  "first; errListErrorOne; errListErrorTwo; errListErrorThree",
 		},
 		{
-			name:         "when errHashableErrorOne is last error, errHashableErrorTwo is mapped and appended",
+			name:         "when errHashableErrorOne is lastErr error, errHashableErrorTwo is mapped and appended",
 			mappedErrors: multipleMappers,
 			givenError:   maperr.Combine(first, errHashableErrorOne),
 			expectedErr:  "first; errHashableErrorOne; errHashableErrorTwo",
@@ -104,7 +104,7 @@ func TestMultiErr_LastMappedWithStatus(t *testing.T) {
 		expected     expected
 	}{
 		{
-			name:         "last error was not found",
+			name:         "lastErr error was not found",
 			mappedErrors: mappedErrorsWithStatus,
 			givenError:   errors.New("not found"),
 		},
@@ -118,7 +118,7 @@ func TestMultiErr_LastMappedWithStatus(t *testing.T) {
 			},
 		},
 		{
-			name:         "last error was mapped and wrapped",
+			name:         "lastErr error was mapped and wrapped",
 			mappedErrors: mappedErrorsWithStatus,
 			givenError:   wrappedSecond,
 			expected: expected{
@@ -199,7 +199,7 @@ func TestMultiErr_MappedWithStatus(t *testing.T) {
 			},
 		},
 		{
-			name:         "last error was not found and nothing was provided",
+			name:         "lastErr error was not found and nothing was provided",
 			mappedErrors: mappedErrorsWithStatus,
 			givenError:   errors.New("not found"),
 			givenDefault: nil,
@@ -208,7 +208,7 @@ func TestMultiErr_MappedWithStatus(t *testing.T) {
 			},
 		},
 		{
-			name:         "last error was not found and a simple error was provided",
+			name:         "lastErr error was not found and a simple error was provided",
 			mappedErrors: mappedErrorsWithStatus,
 			givenError:   errors.New("not found"),
 			givenDefault: errors.New("default error without a status code"),
@@ -218,7 +218,7 @@ func TestMultiErr_MappedWithStatus(t *testing.T) {
 			},
 		},
 		{
-			name:         "last error was not found and a error with status was provided as default",
+			name:         "lastErr error was not found and a error with status was provided as default",
 			mappedErrors: mappedErrorsWithStatus,
 			givenError:   errors.New("not found"),
 			givenDefault: maperr.WithStatus("default error with a status code", http.StatusBadRequest),
@@ -237,7 +237,7 @@ func TestMultiErr_MappedWithStatus(t *testing.T) {
 			},
 		},
 		{
-			name:         "last error was mapped and wrapped",
+			name:         "lastErr error was mapped and wrapped",
 			mappedErrors: mappedErrorsWithStatus,
 			givenError:   wrappedSecond,
 			expected: expected{


### PR DESCRIPTION
Some functions are exported but should have been kept internal only.
This will be made unexported since will keep the api safer to use.

Other changes:
 - Add opensource license
 - Improve readme
 - Remove .github/CODEOWNERS since is not required for opensource
projects