### PR TITLE
Ensure error with status implements maperr.Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ for each error. This library allow you to handle all of them in a single `if` st
 
 ```go
 var errMapper = maperr.NewMultiErr(
-	maperr.NewHashableMapper().
+	maperr.NewListMapper().
 		Append(domain.ErrOne, maperr.WithStatus("err one happened", http.StatusInternalServerError)).
 		Append(domain.ErrTwo, maperr.WithStatus("err two happened", http.StatusBadRequest)).
 		Append(domain.ErrThree, maperr.WithStatus("err three happened", http.StatusConflict)).

--- a/error_test.go
+++ b/error_test.go
@@ -1,22 +1,32 @@
-package maperr_test
+package maperr
 
 import (
 	"errors"
+	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/iZettle/maperr/v4"
 )
 
 func TestErrorf(t *testing.T) {
-	err := maperr.Errorf("some err with foo %d", 123)
+	err := Errorf("some err with foo %d", 123)
 	assert.EqualError(t, err, "some err with foo 123")
 }
 
 func TestNewError(t *testing.T) {
-	err := maperr.NewError("some error")
+	err := NewError("some error")
 	if !err.Equal(errors.New("some error")) {
 		t.Fatal("expected errors to be equal")
+	}
+}
+
+func TestCastError_FromErrorWithStatus(t *testing.T) {
+	errWithStatus := WithStatus("BAD-REQUEST", http.StatusBadRequest)
+
+	castedErr := castError(errWithStatus)
+
+	if !errors.Is(castedErr, errWithStatus) {
+		t.Fatalf("expected %s type %s got %s type %s", errWithStatus, reflect.TypeOf(errWithStatus), castedErr, reflect.TypeOf(castedErr))
 	}
 }

--- a/maperr.go
+++ b/maperr.go
@@ -153,6 +153,21 @@ func (ews errorWithStatus) Error() string {
 	return ews.err.Error()
 }
 
+func (ews errorWithStatus) Hashable() error {
+	return ews
+}
+
+func (ews errorWithStatus) Equal(err error) bool {
+	if err == nil {
+		return false
+	}
+	var errWithStatus errorWithStatus
+	if errors.As(err, &errWithStatus) {
+		return errors.Is(ews.err, errWithStatus.err)
+	}
+	return false
+}
+
 // WithStatus return an error with an associated status
 func WithStatus(err string, status int) error {
 	return errorWithStatus{


### PR DESCRIPTION
Error with statuses were not being mapped correctly as they were
casted to a formatted errors.

This caused errors creted using `maperr.WithStatus` not to work
correctly in combination with the `maperr.NewListMapper`

Satisfies JIRA Ticket: https://izettle.atlassian.net/browse/MSEU-1642