### PR TITLE
Implement Is in maperr.Error interface

### DIFF
--- a/error.go
+++ b/error.go
@@ -11,6 +11,7 @@ type Error interface {
 	error
 	Equal(error) bool
 	Hashable() error
+	Is(err error) bool
 }
 
 // Errorf returns an error which persists
@@ -68,6 +69,11 @@ func (fe formattedError) Unwrap() error {
 // Error return the hashable error
 func (fe formattedError) Hashable() error {
 	return fe.err
+}
+
+// Is is an alias for Equal added to support go 1.13 errors
+func (fe formattedError) Is(err error) bool {
+	return fe.Equal(err)
 }
 
 func (fe formattedError) Equal(err error) bool {

--- a/error_test.go
+++ b/error_test.go
@@ -30,3 +30,56 @@ func TestCastError_FromErrorWithStatus(t *testing.T) {
 		t.Fatalf("expected %s type %s got %s type %s", errWithStatus, reflect.TypeOf(errWithStatus), castedErr, reflect.TypeOf(castedErr))
 	}
 }
+
+func TestFormattedError_Is(t *testing.T) {
+	left := newFormattedError("foo failed: %s", "15644")
+	right := newFormattedError("foo failed: %s", "8745616")
+
+	if !left.Is(right) {
+		t.Fatalf("expected %s to be the same error as %s", left, right)
+	}
+}
+
+func TestFormattedError_Is_NotTheSameFormat(t *testing.T) {
+	left := newFormattedError("foo failed: %s", "15644")
+	right := newFormattedError("bar failed: %s", "8745616")
+
+	if left.Is(right) {
+		t.Fatalf("expected %s not be the same error as %s", left, right)
+	}
+}
+
+func TestFormattedError_Equal(t *testing.T) {
+	left := newFormattedError("foo failed: %s", "15644")
+	right := newFormattedError("foo failed: %s", "8745616")
+
+	if !left.Equal(right) {
+		t.Fatalf("expected %s to be the same error as %s", left, right)
+	}
+}
+
+func TestFormattedError_Equal_NotTheSameFormat(t *testing.T) {
+	left := newFormattedError("foo failed: %s", "15644")
+	right := newFormattedError("bar failed: %s", "8745616")
+
+	if left.Equal(right) {
+		t.Fatalf("expected %s not be the same error as %s", left, right)
+	}
+}
+
+func TestFormattedError_Hashable(t *testing.T) {
+	left := newFormattedError("foo failed: %s", "15644")
+
+	if !errors.Is(left, left.Hashable()) {
+		t.Fatalf("expected %s to be the same error as %s", left, left.Hashable())
+	}
+}
+
+func TestFormattedError_Unwrap(t *testing.T) {
+	err := newFormattedError("foo failed: %s", "15644")
+	expected := "foo failed: 15644"
+
+	if err.Unwrap().Error() != expected {
+		t.Fatalf("expected %s to be the same error as %s", err.Unwrap().Error(), expected)
+	}
+}

--- a/error_with_status.go
+++ b/error_with_status.go
@@ -1,0 +1,59 @@
+package maperr
+
+import (
+	"errors"
+)
+
+// WithStatus return an error with an associated status
+func WithStatus(err string, status int) error {
+	return errorWithStatus{
+		err:    errors.New(err),
+		status: status,
+	}
+}
+
+type errorWithStatus struct {
+	err    error
+	status int
+	cause  error
+}
+
+func newErrorWithStatus(err, cause error, status int) errorWithStatus {
+	return errorWithStatus{
+		err:    err,
+		status: status,
+		cause:  cause,
+	}
+}
+
+func (ews errorWithStatus) Status() int {
+	return ews.status
+}
+
+func (ews errorWithStatus) Unwrap() error {
+	return ews.cause
+}
+
+func (ews errorWithStatus) Error() string {
+	return ews.err.Error()
+}
+
+func (ews errorWithStatus) Hashable() error {
+	return ews
+}
+
+// Is is an alias for Equal added to support go 1.13 errors
+func (ews errorWithStatus) Is(err error) bool {
+	return ews.Equal(err)
+}
+
+func (ews errorWithStatus) Equal(err error) bool {
+	if err == nil {
+		return false
+	}
+	var errWithStatus errorWithStatus
+	if errors.As(err, &errWithStatus) {
+		return errors.Is(ews.err, errWithStatus.err)
+	}
+	return false
+}

--- a/error_with_status_test.go
+++ b/error_with_status_test.go
@@ -1,0 +1,70 @@
+package maperr
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+func TestErrorWithStatus_Hashable(t *testing.T) {
+	errMissingField := errors.New("MISSING_FIELD")
+	errWithStatus := newErrorWithStatus(errMissingField, errors.New("could not fill struct"), http.StatusBadRequest)
+
+	if !errors.Is(errWithStatus, errWithStatus.Hashable()) {
+		t.Fatalf("expected %s to be the same error as %s", errWithStatus, errWithStatus.Hashable())
+	}
+}
+
+func TestErrorWithStatus_Is(t *testing.T) {
+	errMissingField := errors.New("MISSING_FIELD")
+	left := newErrorWithStatus(errMissingField, errors.New("could not fill struct"), http.StatusBadRequest)
+	right := newErrorWithStatus(errMissingField, errors.New("could not fill struct"), http.StatusBadRequest)
+
+	if !left.Is(right) {
+		t.Fatalf("expected %s to be the same error as %s", left, right)
+	}
+}
+
+func TestErrorWithStatus_Is_NotTheSameError(t *testing.T) {
+	left := newErrorWithStatus(errors.New("MISSING_FIELD_ONE"), errors.New("could not fill struct"), http.StatusBadRequest)
+	right := newErrorWithStatus(errors.New("MISSING_FIELD_TWO"), errors.New("could not fill struct"), http.StatusBadRequest)
+
+	if left.Is(right) {
+		t.Fatalf("expected %s to be the different error than %s", left, right)
+	}
+}
+
+func TestErrorWithStatus_Is_NilError(t *testing.T) {
+	errWithStatus := newErrorWithStatus(nil, errors.New("could not fill struct"), http.StatusBadRequest)
+
+	if errWithStatus.Is(nil) {
+		t.Fatalf("expected %s to be the different error than nil", errWithStatus)
+	}
+}
+
+func TestErrorWithStatus_Equal(t *testing.T) {
+	errMissingField := errors.New("MISSING_FIELD")
+	left := newErrorWithStatus(errMissingField, errors.New("could not fill struct"), http.StatusBadRequest)
+	right := newErrorWithStatus(errMissingField, errors.New("could not fill struct"), http.StatusBadRequest)
+
+	if !left.Equal(right) {
+		t.Fatalf("expected %s to be the same error as %s", left, right)
+	}
+}
+
+func TestErrorWithStatus_Equal_NotTheSameError(t *testing.T) {
+	left := newErrorWithStatus(errors.New("MISSING_FIELD_ONE"), errors.New("could not fill struct"), http.StatusBadRequest)
+	right := newErrorWithStatus(errors.New("MISSING_FIELD_TWO"), errors.New("could not fill struct"), http.StatusBadRequest)
+
+	if left.Equal(right) {
+		t.Fatalf("expected %s to be the different error than %s", left, right)
+	}
+}
+
+func TestErrorWithStatus_Equal_NilError(t *testing.T) {
+	errWithStatus := newErrorWithStatus(nil, errors.New("could not fill struct"), http.StatusBadRequest)
+
+	if errWithStatus.Equal(nil) {
+		t.Fatalf("expected %s to be the different error than nil", errWithStatus)
+	}
+}

--- a/maperr.go
+++ b/maperr.go
@@ -127,55 +127,6 @@ func (m MultiErr) LastMappedWithStatus(err error) ErrorWithStatusProvider {
 	return m.MappedWithStatus(err, nil)
 }
 
-type errorWithStatus struct {
-	err    error
-	status int
-	cause  error
-}
-
-func newErrorWithStatus(err, cause error, status int) errorWithStatus {
-	return errorWithStatus{
-		err:    err,
-		status: status,
-		cause:  cause,
-	}
-}
-
-func (ews errorWithStatus) Status() int {
-	return ews.status
-}
-
-func (ews errorWithStatus) Unwrap() error {
-	return ews.cause
-}
-
-func (ews errorWithStatus) Error() string {
-	return ews.err.Error()
-}
-
-func (ews errorWithStatus) Hashable() error {
-	return ews
-}
-
-func (ews errorWithStatus) Equal(err error) bool {
-	if err == nil {
-		return false
-	}
-	var errWithStatus errorWithStatus
-	if errors.As(err, &errWithStatus) {
-		return errors.Is(ews.err, errWithStatus.err)
-	}
-	return false
-}
-
-// WithStatus return an error with an associated status
-func WithStatus(err string, status int) error {
-	return errorWithStatus{
-		err:    errors.New(err),
-		status: status,
-	}
-}
-
 // LastAppended return the lastErr error appended as multierr
 func LastAppended(err error) error {
 	if errList := multierr.Errors(err); len(errList) > 0 {


### PR DESCRIPTION
In order to make the `maperr.Error` fully compatible with go errors 1.13
we need to implement the Is(err) bool interface.

Since maperr already has Equal(error) bool, we can just add `Is` as an
alias of `Equal`

Satisfies JIRA Ticket: https://izettle.atlassian.net/browse/MSEU-1642