### PR TITLE
Bump aws-ecr orb to alleviate use of expired CI ubuntu images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 orbs:
-  aws-ecr: circleci/aws-ecr@6.5.0
+  aws-ecr: circleci/aws-ecr@8.1.2
 
 executors:
   golang:


### PR DESCRIPTION
Older versions of the CircleCI Orb `aws-ecr` use Ubuntu 16.04 which has been
removed from CircleCI as of
[2022-05-31](https://circleci.com/blog/ubuntu-14-16-image-deprecation/). To have
the service build even after that date, this commit bumps `aws-ecr` to the
latest version 8.1.2 which uses a supported version of Ubuntu: 20.04.

[aws-ecr v6.5.0](https://circleci.com/developer/orbs/orb/circleci/aws-ecr?version=6.5.0)
[aws-ecr v8.1.2](https://circleci.com/developer/orbs/orb/circleci/aws-ecr?version=8.1.2)
