### PR TITLE
Trigger CircleCI pipeline for Dependabot PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,17 @@
 ---
 version: 2.1
 
+parameters:
+  GHA_Actor:
+    type: string
+    default: ""
+  GHA_Action:
+    type: string
+    default: ""
+  GHA_Event:
+    type: string
+    default: ""
+
 orbs:
   aws-ecr: circleci/aws-ecr@6.5.0
 

--- a/.github/workflows/trigger-circleci-pipeline-on-dependabot-pr.yml
+++ b/.github/workflows/trigger-circleci-pipeline-on-dependabot-pr.yml
@@ -1,0 +1,8 @@
+name: Trigger CircleCI pipeline for Dependabot PRs
+
+on: pull_request_target
+
+jobs:
+  trigger-cci-pipeline:
+    uses: iZettle/.github/.github/workflows/trigger-circleci-pipeline-on-dependabot-pr.yml@main
+    secrets: inherit


### PR DESCRIPTION
## What
Trigger the CircleCI pipeline once again using our own in-house izettle-ci bot which is already part of the Github team that has access to all the secrets.

## Why
Dependabot does not have permissions to trigger the the CircleCI pipeline. Meaning Dependabot PRs are not approved/merged automatically, which brings manual work for us to merge minor dependency changes.

## How
Trigger the CircleCI pipeline once again using a GitHub Action.

## More information
- Trigger added as suggested [here](https://izettle.atlassian.net/wiki/spaces/PSS/pages/4328292377/Best+Practices+for+Using+CircleCI+Secrets).

---

This PR does not knowingly introduce security vulnerabilities, such as [OWASP Top 10](https://owasp.org/Top10).
Contributors and reviewers adhere to the Development Manifesto on [Security](https://github.com/iZettle/tech-guidelines/blob/main/developer-manifesto.md#security).
