### PR TITLE
ECS - Implement Synopsys Nightly Scans

### DIFF
--- a/.github/workflows/ecs-nightly-scans.yml
+++ b/.github/workflows/ecs-nightly-scans.yml
@@ -1,0 +1,31 @@
+name: ECS - SAST OSS Nightly Scanss
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+  workflow_dispatch:
+
+jobs:
+  Scans:
+    runs-on: SynopsysManagedRunner
+    
+    permissions:
+      id-token: write
+      contents: read
+      
+    steps:
+      - uses: actions/checkout@v2
+      - run: pip3 install pygithub
+      
+      - name: SAST-OSS-Scans
+        uses: iZettle/ScanCLI/action@main
+        with:
+          POLARIS_ACCESS_TOKEN: ${{ secrets.POLARIS_ACCESS_TOKEN }}
+          BLACKDUCK_ACCESS_TOKEN: ${{ secrets.BLACKDUCK_ACCESS_TOKEN }}
+          BOT_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          ZETTLE_SHARED_SERVICES_ECR_OIDC_ROLE_ARN: ${{ vars.ZETTLE_SHARED_SERVICES_ECR_OIDC_ROLE_ARN }}
+          ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
+          ARTIFACTORY_API_KEY: ${{ secrets.ARTIFACTORY_API_KEY }}
+          APPNAME: ${{ github.repository }}
+


### PR DESCRIPTION
## Summary
A PR request to enable nightly security scans of Zettle repos using Synpsys tools and ScanCLI **Please merge this PR ASAP**

## Background
Performing security scans on all code deployed to production is a vital part of any development workflow. It helps us 
prevent security issues from reaching production and reduces the cost of resolving such issues. Synopsys tools (BlackDuck 
and Coverity) were chosen by PayPal for use in all BUs when performing Static Application Security Testing (SAST) and 
Open-Source Security scanning (OSS). This PR implement the first step of the integration, nightly scans. Other, more 
involved integrations (e.g. PR scanning) will be implemented later on.

## Changes
- This PR will add a new GitHub action to each repo. The action will run nightly. - No other changes are made to any files 
within the repo.

## Disruptions
The proposed change is simple in nature and poses no little to no risk of disturbing the normal development workflows.

## Contact
If any issues arise after merging the PR, please reach out to Ahmed Musaad
